### PR TITLE
Peer config accepts IP Address and Subnet+Mask

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
     - master
+    - *
   pull_request:
     branches:
     - master

--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -3,11 +3,10 @@ name: cargo
 on:
   push:
     branches:
-    - master
-    - *
+    - '*'
   pull_request:
     branches:
-    - master
+    - '*'
   schedule:
     - cron: 0 5 * * 1,5
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ dependencies = [
  "chrono 0.4.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "ipnetwork 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpsee 1.0.0 (git+https://github.com/paritytech/jsonrpsee)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -513,6 +514,14 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.66 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "ipnetwork"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1343,6 +1352,7 @@ dependencies = [
 "checksum hyper 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8bf49cfb32edee45d890537d9057d1b02ed55f53b7b6a30bae83a38c9231749e"
 "checksum indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b54058f0a6ff80b6803da8faf8997cde53872b38f4023728f6830b06cd3c0dc"
 "checksum iovec 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b2b3ea6ff95e175473f8ffe6a7eb7c00d054240321b84c57051175fe3c1e075e"
+"checksum ipnetwork 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b8eca9f51da27bc908ef3dd85c21e1bbba794edaf94d7841e37356275b82d31e"
 "checksum itertools 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f56a2d0bc861f9165be4eb3442afd3c236d8a98afd426f65d92324ae1091a484"
 "checksum itoa 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "501266b7edd0174f8530248f87f99c88fbe60ca4ef3dd486835b8d8d53136f7f"
 "checksum jsonrpsee 1.0.0 (git+https://github.com/paritytech/jsonrpsee)" = "<none>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ bytes = "^0.5.3"
 byteorder = "1.3.1"
 chrono = { version = "0.4.7", features = ["serde"] }
 env_logger = "0.6.1"
+ipnetwork = "^0.16"
 itertools = "^0.8.1"
 jsonrpsee = { git = "https://github.com/paritytech/jsonrpsee", default-features = false, features = ["http"] }
 futures = { version = "^0.3" }

--- a/examples/cli/README.md
+++ b/examples/cli/README.md
@@ -18,7 +18,7 @@ This is an example CLI that uses the BGPd API to interact with a running instanc
 Use `bgpd-cli` for viewing peer & route information:
 
 Peer summary:
-```
+```sh
 [~/bgpd-rs/examples/cli] $ cargo run -- show neighbors
  Neighbor     Router ID    AS     MsgRcvd  MsgSent  Uptime    State        PfxRcd
 ----------------------------------------------------------------------------------
@@ -29,7 +29,7 @@ Peer summary:
  > Tip: Use the `watch` command for keeping this view up-to-date
 
 Peer Detail:
-```
+```sh
 BGP neighbor is 127.0.0.3,  remote AS 65000, local AS 65000
   *Peer is Disabled
   Neighbor capabilities:
@@ -58,7 +58,7 @@ BGP neighbor is 172.16.20.2,  remote AS 65000, local AS 65000
 ## Routes
 
 Learned routes:
-```
+```sh
 [~/bgpd-rs/examples/cli] $ cargo build
 [~/bgpd-rs/examples/cli] $ ./targets/debug/bgpd-cli show routes learned
 IPv4 / Unicast
@@ -85,7 +85,7 @@ IPv6 / Unicast
 ```
 
 Advertised routes:
-```
+```sh
 [~/bgpd-rs/examples/cli] $ ./targets/debug/bgpd-cli show routes advertised
 IPv4 / Unicast
  Advertised To  Prefix          Next Hop      Age       Origin      Local Pref  Metric  AS Path  Communities  Age
@@ -105,7 +105,7 @@ IPv6 / Unicast
 
 ### Unicast
 IPv4 Unicast
-```
+```sh
 [~/bgpd-rs/examples/cli] $ ./targets/debug/bgpd-cli advertise route 10.10.10.0/24 172.16.20.90 --local-pref 500
 Added route to RIB for announcement:
  Received From  Prefix         Next Hop      Age       Origin      Local Pref  Metric  AS Path  Communities  Age
@@ -114,7 +114,7 @@ Added route to RIB for announcement:
 ```
 
 IPv6 Unicast
-```
+```sh
 [~/bgpd-rs/examples/cli] $ ./targets/debug/bgpd-cli advertise route 10.10.10.0/24 172.16.20.90 --local-pref 500
 Added route to RIB for announcement:
  Received From  Prefix         Next Hop      Age       Origin      Local Pref  Metric  AS Path  Communities  Age
@@ -122,7 +122,7 @@ Added route to RIB for announcement:
  API            10.10.10.0/24  172.16.20.90  00:00:00  Incomplete                                            00:00:00
 ```
 
-```
+```sh
 [~/bgpd-rs/examples/cli] $ ./targets/debug/bgpd-cli show routes advertised
 IPv4 / Unicast
  Advertised To  Prefix          Next Hop      Age       Origin      Local Pref  Metric  AS Path  Communities  Age
@@ -138,7 +138,7 @@ IPv6 / Unicast
 ```
 
 ### Flowspec
-```
+```sh
 [~/bgpd-rs/examples/cli] $ ./targets/debug/bgpd-cli advertise flow ipv4 'traffic-rate 100' -m 'source 192.168.10.0/24'
 Added flow to RIB for announcement:
  Received From  Prefix               Next Hop  Age       Origin      Local Pref  Metric  AS Path  Communities            Age
@@ -151,7 +151,7 @@ Added flow to RIB for announcement:
  Config         Dst 3001:10:20::/64            00:00:00  Incomplete                               redirect:100:200  00:00:00
  ```
 
- ```
+ ```sh
 [~/bgpd-rs/examples/cli] $ ./targets/debug/bgpd-cli  show routes learned
 IPv4 / Flowspec
  Received From  Prefix              Next Hop  Age       Origin      Local Pref  Metric  AS Path  Communities     Age

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -4,7 +4,7 @@ poll_interval = 5
 
 
 [[peers]]
-remote_ip = "127.0.0.2"
+remote_ip = "127.0.0.0/30"
 dest_port = 1179
 remote_as = 65000
 local_as = 65000
@@ -30,11 +30,15 @@ as_path = ["65000", "500"]
 communities = ["101", "202", "65000:99"]
 
 [[peers]]
-remote_ip = "127.0.0.3"
+remote_ip = "::2"
 dest_port = 1179
 remote_as = 65000
 local_as = 65000
-hold_timer = 30
+families = [
+    "ipv6 unicast",
+    "ipv6 flow",
+]
+passive = true
 advertise_sources = [       # Default is API & Config, you can add peer advertisements
     "api", "peer", "config",
 ]
@@ -48,15 +52,3 @@ matches= [
 ]
 as_path = ["65000", "500"]
 communities = ["101", "202", "65000:99"]
-
-
-[[peers]]
-remote_ip = "::2"
-dest_port = 1179
-remote_as = 65000
-local_as = 65000
-families = [
-    "ipv6 unicast",
-    "ipv6 flow",
-]
-passive = true

--- a/examples/config.toml
+++ b/examples/config.toml
@@ -4,7 +4,9 @@ poll_interval = 5
 
 
 [[peers]]
-remote_ip = "127.0.0.0/30"
+remote_ip = "127.0.0.0/30"  # Can be a network or single peer (without CIDR mask)
+                            # Networks larger than 1 host will be implicitly passive
+                            # and will accept any inbound peering sourced from the subnet
 dest_port = 1179
 remote_as = 65000
 local_as = 65000

--- a/rpc_lib/src/lib.rs
+++ b/rpc_lib/src/lib.rs
@@ -16,7 +16,7 @@ jsonrpsee::rpc_api! {
 
 #[derive(Debug, Deserialize, Serialize)]
 pub struct PeerSummary {
-    pub peer: IpAddr,
+    pub peer: String,
     pub enabled: bool,
     pub router_id: Option<IpAddr>,
     pub remote_asn: u32,

--- a/src/api/handler.rs
+++ b/src/api/handler.rs
@@ -22,58 +22,63 @@ pub async fn serve(socket: SocketAddr, state: Arc<State>) {
                 Api::ShowPeers { respond } => {
                     let mut output: Vec<PeerSummary> = vec![];
                     let sessions = state.sessions.lock().await;
-                    let peers = sessions.get_peer_configs();
+                    let configs = sessions.get_peer_configs();
                     let active_sessions = sessions.sessions.lock().await;
                     let rib = state.rib.lock().await;
-                    let peer_info = peers
+                    // Summary for any non-idle sessions
+                    let session_summaries: Vec<PeerSummary> = active_sessions
+                        .iter()
+                        .map(|(addr, session)| {
+                            let pfx_rcvd = rib.get_routes_from_peer(*addr).len() as u64;
+                            peer_to_summary(session.config.clone(), Some(session), Some(pfx_rcvd))
+                        })
+                        .collect();
+                    output.extend(session_summaries);
+                    // Summaries for idle peer/network configs
+                    let idle_summaries = configs
                         .into_iter()
                         .filter_map(|config| {
                             if let Some(remote_ip) = get_host_address(&config.remote_ip) {
-                                let session = active_sessions.get(&remote_ip);
-                                let pfx_rcvd = {
-                                    if let Some(session) = session {
-                                        let routes = rib.get_routes_from_peer(session.addr);
-                                        Some(routes.len() as u64)
-                                    } else {
-                                        None
-                                    }
-                                };
-                                Some(peer_to_summary(config, session, pfx_rcvd))
-                            } else {
-                                None
+                                // Don't duplicate session summaries
+                                if active_sessions.get(&remote_ip).is_some() {
+                                    return None;
+                                }
                             }
+                            Some(peer_to_summary(config, None, None))
                         })
                         .collect::<Vec<PeerSummary>>();
-                    output.extend(peer_info);
+                    output.extend(idle_summaries);
                     respond.ok(output).await;
                 }
                 Api::ShowPeerDetail { respond } => {
                     let mut output: Vec<PeerDetail> = vec![];
                     let sessions = state.sessions.lock().await;
-                    let peers = sessions.get_peer_configs();
+                    let configs = sessions.get_peer_configs();
                     let active_sessions = sessions.sessions.lock().await;
                     let rib = state.rib.lock().await;
-                    let peer_info = peers
-                        .into_iter()
-                        .map(|config| {
-                            if let Some(remote_ip) = get_host_address(&config.remote_ip) {
-                                let session = active_sessions.get(&remote_ip);
-                                let pfx_rcvd = {
-                                    if let Some(session) = session {
-                                        let routes = rib.get_routes_from_peer(session.addr);
-                                        Some(routes.len() as u64)
-                                    } else {
-                                        None
-                                    }
-                                };
-                                Some(peer_to_detail(config, session, pfx_rcvd))
-                            } else {
-                                None
-                            }
+                    // Detail for any non-idle sessions
+                    let session_details: Vec<PeerDetail> = active_sessions
+                        .iter()
+                        .map(|(addr, session)| {
+                            let pfx_rcvd = rib.get_routes_from_peer(*addr).len() as u64;
+                            peer_to_detail(session.config.clone(), Some(session), Some(pfx_rcvd))
                         })
-                        .filter_map(|p| p.map(|c| c))
-                        .collect::<Vec<PeerDetail>>();
-                    output.extend(peer_info);
+                        .collect();
+                    output.extend(session_details);
+                    // Details for idle peer/network configs
+                    let idle_details: Vec<PeerDetail> = configs
+                        .into_iter()
+                        .filter_map(|config| {
+                            if let Some(remote_ip) = get_host_address(&config.remote_ip) {
+                                // Don't duplicate session details
+                                if active_sessions.get(&remote_ip).is_some() {
+                                    return None;
+                                }
+                            }
+                            Some(peer_to_detail(config, None, None))
+                        })
+                        .collect();
+                    output.extend(idle_details);
                     respond.ok(output).await;
                 }
                 Api::ShowRoutesLearned { respond, from_peer } => {

--- a/src/api/peers.rs
+++ b/src/api/peers.rs
@@ -5,7 +5,7 @@ use bgpd_rpc_lib::{PeerDetail, PeerSummary};
 
 use crate::config::PeerConfig;
 use crate::session::{Session, SessionState};
-use crate::utils::format_time_as_elapsed;
+use crate::utils::{format_time_as_elapsed, get_host_address};
 
 pub fn peer_to_summary(
     config: Arc<PeerConfig>,
@@ -13,9 +13,13 @@ pub fn peer_to_summary(
     prefixes_received: Option<u64>,
 ) -> PeerSummary {
     PeerSummary {
-        peer: session
-            .map(|s| s.addr.to_string())
-            .unwrap_or_else(|| config.remote_ip.to_string()),
+        peer: session.map(|s| s.addr.to_string()).unwrap_or_else(|| {
+            if let Some(addr) = get_host_address(&config.remote_ip) {
+                addr.to_string()
+            } else {
+                config.remote_ip.to_string()
+            }
+        }),
         enabled: config.enabled,
         router_id: session.map(|s| s.router_id),
         remote_asn: config.remote_as,

--- a/src/api/peers.rs
+++ b/src/api/peers.rs
@@ -13,7 +13,9 @@ pub fn peer_to_summary(
     prefixes_received: Option<u64>,
 ) -> PeerSummary {
     PeerSummary {
-        peer: session.map(|s| s.addr).unwrap_or(config.remote_ip),
+        peer: session
+            .map(|s| s.addr.to_string())
+            .unwrap_or_else(|| config.remote_ip.to_string()),
         enabled: config.enabled,
         router_id: session.map(|s| s.router_id),
         remote_asn: config.remote_as,

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -5,6 +5,7 @@ use std::net::IpAddr;
 
 use bgp_rs::{AFI, SAFI};
 use bgpd_rpc_lib::{FlowSpec, RouteSpec};
+use ipnetwork::IpNetwork;
 use serde::{self, Deserialize, Deserializer, Serialize, Serializer};
 use toml;
 
@@ -49,7 +50,7 @@ impl Defaults {
 #[derive(Clone, Debug, Deserialize)]
 pub(super) struct PeerConfigSpec {
     // Peer connection details
-    pub(super) remote_ip: IpAddr,
+    pub(super) remote_ip: IpNetwork,
     pub(super) remote_as: u32,
     // Local connection details
     pub(super) local_as: Option<u32>,

--- a/src/config/file.rs
+++ b/src/config/file.rs
@@ -170,11 +170,14 @@ mod tests {
         let config = ServerConfigSpec::from_file("./examples/config.toml").unwrap();
         assert_eq!(config.router_id, IpAddr::from(Ipv4Addr::new(1, 1, 1, 1)));
         assert_eq!(config.default_as, 65000);
-        assert_eq!(config.peers.len(), 3);
+        assert_eq!(config.peers.len(), 2);
         let v4_peer = config
             .peers
             .iter()
-            .find(|p| p.remote_ip == IpAddr::from(Ipv4Addr::new(127, 0, 0, 2)))
+            .find(|p| {
+                p.remote_ip
+                    == IpNetwork::new(IpAddr::from(Ipv4Addr::new(127, 0, 0, 0)), 30).unwrap()
+            })
             .unwrap();
         assert_eq!(v4_peer.local_as, Some(65000));
         assert_eq!(v4_peer.hold_timer, 30);
@@ -184,7 +187,11 @@ mod tests {
         let v6_peer = config
             .peers
             .iter()
-            .find(|p| p.remote_ip == IpAddr::from("::2".parse::<Ipv6Addr>().unwrap()))
+            .find(|p| {
+                p.remote_ip
+                    == IpNetwork::new(IpAddr::from("::2".parse::<Ipv6Addr>().unwrap()), 128)
+                        .unwrap()
+            })
             .unwrap();
         assert_eq!(v6_peer.families.len(), 2);
         assert_eq!(v6_peer.hold_timer, 180);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,8 +7,8 @@ use std::io::Result;
 use std::net::IpAddr;
 use std::sync::Arc;
 
-use ipnetwork::IpNetwork;
 use bgpd_rpc_lib::{FlowSpec, RouteSpec};
+use ipnetwork::IpNetwork;
 
 use crate::rib::Family;
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -7,6 +7,7 @@ use std::io::Result;
 use std::net::IpAddr;
 use std::sync::Arc;
 
+use ipnetwork::IpNetwork;
 use bgpd_rpc_lib::{FlowSpec, RouteSpec};
 
 use crate::rib::Family;
@@ -29,7 +30,7 @@ pub struct ServerConfig {
 ///   Has missing PeerConfigSpec items defaulted to Server values
 #[derive(Debug)]
 pub struct PeerConfig {
-    pub remote_ip: IpAddr,
+    pub remote_ip: IpNetwork,
     pub remote_as: u32,
     pub local_as: u32,
     pub local_router_id: IpAddr,

--- a/src/session/manager.rs
+++ b/src/session/manager.rs
@@ -119,7 +119,7 @@ impl SessionManager {
                             _ => (),
                         }
                         warn!("{}", err);
-                        self.poller_tx.send(session.peer.clone()).unwrap();
+                        self.poller_tx.send(session.config.clone()).unwrap();
                         ended_sessions.push(*remote_ip);
                     }
                 }
@@ -148,8 +148,8 @@ impl SessionManager {
                     }
                     let protocol = MessageProtocol::new(stream, MessageCodec::new());
                     let new_session = Session::new(Arc::clone(&peer_config), protocol);
+                    info!("New session started: {}", remote_ip);
                     sessions.insert(remote_ip, new_session);
-                    info!("New session started: {}", peer_config.remote_ip);
                 }
                 Ok(None)
             },

--- a/src/session/poller.rs
+++ b/src/session/poller.rs
@@ -89,16 +89,18 @@ impl Poller {
         }
     }
 
-    pub fn upsert_peer(&mut self, config: Arc<PeerConfig>) {
+    pub fn upsert_config(&mut self, config: Arc<PeerConfig>) {
         let network = config.remote_ip;
 
-        if let Some(_existing_peer) = self
+        if self
             .idle_peers
             .insert(config.remote_ip, IdlePeer::new(config))
+            .is_some()
         {
             debug!("Peer config for {} updated", network);
-        }
-        if let Some(remote_ip) = get_host_address(&network) {
+        } else if let Some(remote_ip) = get_host_address(&network) {
+            // Add to outgoing connection queue if there was no existing config
+            // and if it's a single host
             self.delay_queue.insert(remote_ip, self.interval);
         }
     }

--- a/src/session/session.rs
+++ b/src/session/session.rs
@@ -5,8 +5,8 @@ use std::net::IpAddr;
 use std::sync::Arc;
 
 use bgp_rs::{
-    ASPath, Capabilities, MPReachNLRI, Message, NLRIEncoding, Open, OpenCapability, OpenParameter,
-    PathAttribute, Segment, Update, AFI, SAFI,
+    ASPath, Capabilities, MPReachNLRI, Message, NLRIEncoding, Notification, Open, OpenCapability,
+    OpenParameter, PathAttribute, Segment, Update, AFI, SAFI,
 };
 use chrono::{DateTime, Utc};
 use futures::{SinkExt, StreamExt};
@@ -235,6 +235,15 @@ impl Session {
         self.counts.increment_sent();
         self.hold_timer.sent();
         Ok(())
+    }
+
+    pub async fn notify(&mut self, maj: u8, min: u8) -> Result<(), io::Error> {
+        let notif = Notification {
+            major_err_code: maj,
+            minor_err_code: min,
+            data: vec![],
+        };
+        self.send_message(Message::Notification(notif)).await
     }
 
     pub fn open_received(

--- a/src/session/session.rs
+++ b/src/session/session.rs
@@ -29,7 +29,7 @@ pub struct Session {
     pub(crate) addr: IpAddr,
     pub(crate) state: SessionState,
     pub(crate) router_id: IpAddr,
-    pub(crate) peer: Arc<PeerConfig>,
+    pub(crate) config: Arc<PeerConfig>,
     pub(crate) protocol: MessageProtocol,
     pub(crate) connect_time: DateTime<Utc>,
     pub(crate) hold_timer: HoldTimer,
@@ -39,11 +39,11 @@ pub struct Session {
 }
 
 impl Session {
-    pub fn new(peer: Arc<PeerConfig>, protocol: MessageProtocol) -> Session {
-        let hold_timer = peer.hold_timer;
-        let capabilities: Vec<OpenCapability> = vec![OpenCapability::FourByteASN(peer.local_as)]
+    pub fn new(config: Arc<PeerConfig>, protocol: MessageProtocol) -> Session {
+        let hold_timer = config.hold_timer;
+        let capabilities: Vec<OpenCapability> = vec![OpenCapability::FourByteASN(config.local_as)]
             .into_iter()
-            .chain(peer.families.iter().map(|f| f.to_open_param()))
+            .chain(config.families.iter().map(|f| f.to_open_param()))
             .collect();
         let session_rib = SessionRoutes::new(Families::new(vec![]));
         Session {
@@ -58,7 +58,7 @@ impl Session {
                 .peer_addr()
                 .expect("Protocol has remote peer")
                 .ip(),
-            peer,
+            config,
             protocol,
             connect_time: Utc::now(),
             hold_timer: HoldTimer::new(hold_timer),
@@ -80,7 +80,7 @@ impl Session {
             .peer_addr()
             .expect("Getting remote addr")
             .port();
-        remote_port == self.peer.dest_port
+        remote_port == self.config.dest_port
     }
 
     pub fn update_state(&mut self, new_state: SessionState) {
@@ -95,13 +95,13 @@ impl Session {
 
     pub fn update_config(&mut self, new_config: Arc<PeerConfig>) {
         debug!("Peer config for {} (active session) updated", self.addr);
-        self.peer = new_config;
+        self.config = new_config;
     }
 
     /// Main function for making progress with the session
     /// Waits for either a new incoming message or a HoldTimer event
     pub async fn run(&mut self) -> Result<Option<SessionUpdate>, SessionError> {
-        if !self.peer.enabled {
+        if !self.config.enabled {
             // Peer has been disabled, shutdown session
             return Err(SessionError::Deconfigured);
         }
@@ -168,7 +168,7 @@ impl Session {
                     EntrySource::Config => AdvertiseSource::Config,
                     EntrySource::Peer(_) => AdvertiseSource::Peer,
                 };
-                self.peer.advertise_sources.contains(&source)
+                self.config.advertise_sources.contains(&source)
             })
             .collect();
         if !pending_routes.is_empty() {
@@ -243,13 +243,13 @@ impl Session {
     ) -> Result<(Capabilities, u16), SessionError> {
         let router_id = IpAddr::from(transform_u32_to_bytes(received_open.identifier));
         let remote_asn = asn_from_open(&received_open);
-        if remote_asn != self.peer.remote_as {
+        if remote_asn != self.config.remote_as {
             return Err(SessionError::OpenAsnMismatch(
                 remote_asn,
-                self.peer.remote_as,
+                self.config.remote_as,
             ));
         }
-        let hold_timer = cmp::min(received_open.hold_timer, self.peer.hold_timer);
+        let hold_timer = cmp::min(received_open.hold_timer, self.config.hold_timer);
         debug!(
             "[{}] Received OPEN [w/ {} params]",
             self.addr,
@@ -262,22 +262,22 @@ impl Session {
     }
 
     pub fn create_open(&self) -> Open {
-        let router_id = match self.peer.local_router_id {
+        let router_id = match self.config.local_router_id {
             IpAddr::V4(ipv4) => ipv4,
             _ => unreachable!(),
         };
         let families: Vec<_> = self
-            .peer
+            .config
             .families
             .iter()
             .map(|family| family.to_open_param())
             .collect();
         let mut capabilities: Vec<OpenCapability> =
-            Vec::with_capacity(self.peer.families.len() + 1);
+            Vec::with_capacity(self.config.families.len() + 1);
         capabilities.extend(families);
-        capabilities.push(OpenCapability::FourByteASN(self.peer.local_as));
-        let two_byte_asn = if self.peer.local_as < 65535 {
-            self.peer.local_as as u16
+        capabilities.push(OpenCapability::FourByteASN(self.config.local_as));
+        let two_byte_asn = if self.config.local_as < 65535 {
+            self.config.local_as as u16
         } else {
             // AS-TRANS: RFC 6793 [4.2.3.9]
             23456
@@ -305,22 +305,22 @@ impl Session {
         ));
 
         let mut as_path = update.attributes.as_path.clone();
-        if self.peer.is_ebgp() {
+        if self.config.is_ebgp() {
             if as_path.segments.is_empty() {
                 as_path
                     .segments
-                    .push(Segment::AS_SEQUENCE(vec![self.peer.local_as]));
+                    .push(Segment::AS_SEQUENCE(vec![self.config.local_as]));
             } else {
                 // TODO: Support multiple segments?
                 let segment = match &as_path.segments[0] {
                     Segment::AS_SEQUENCE(seq) => {
                         let mut seg = seq.clone();
-                        seg.insert(0, self.peer.local_as);
+                        seg.insert(0, self.config.local_as);
                         Segment::AS_SEQUENCE(seg)
                     }
                     Segment::AS_SET(set) => {
                         let mut seg = set.clone();
-                        seg.insert(0, self.peer.local_as);
+                        seg.insert(0, self.config.local_as);
                         Segment::AS_SET(seg)
                     }
                 };

--- a/src/session/session.rs
+++ b/src/session/session.rs
@@ -53,7 +53,11 @@ impl Session {
                 .expect("Stream has remote IP")
                 .ip(),
             state: SessionState::Connect,
-            router_id: peer.remote_ip,
+            router_id: protocol
+                .get_ref()
+                .peer_addr()
+                .expect("Protocol has remote peer")
+                .ip(),
             peer,
             protocol,
             connect_time: Utc::now(),

--- a/src/utils/display.rs
+++ b/src/utils/display.rs
@@ -1,5 +1,6 @@
 use std::net::IpAddr;
 
+use bgp_rs::Message;
 use chrono::{DateTime, Duration, TimeZone, Utc};
 
 use super::*;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -3,8 +3,6 @@ pub use display::*;
 mod parse;
 pub use parse::*;
 
-use bgp_rs::Message;
-
 pub fn transform_u8_to_bytes(x: u8) -> [u8; 1] {
     let b1: u8 = x as u8;
     [b1]


### PR DESCRIPTION
Adding the ability to configure a single IP address (existing feature) and a subnet + mask (new feature).

IP Address peers:
- Accept incoming connections source from that IP Address
- Periodically initiates outbound connections to the IP Address (if config.passive == true)

Subnet + Mask peers:
- Accept incoming connections source from any IP Address in the subnet
- Will not initiate outbound connections to any device in the subnet (implicitly passive)

API changes:
- IP Address in PeerSummary/PeerDetail is now a string to support the format of a single IP or a network + CIDR mask length